### PR TITLE
Add .NET 8 as target framework for compiler

### DIFF
--- a/src/Xcst.Compiler/Xcst.Compiler.csproj
+++ b/src/Xcst.Compiler/Xcst.Compiler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;net8.0</TargetFrameworks>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>NETSDK1138,NU1903</NoWarn>
@@ -48,7 +48,7 @@
           DependsOnTargets="ResolveReferences"
           Inputs="@(XcstInput);$(MSBuildThisFileFullPath)"
           Outputs="$(XcstOutput)">
-    <MSBuild Projects="..\compiler-codegen\compiler-codegen.csproj" Properties="TargetFramework=net7.0">
+    <MSBuild Projects="..\compiler-codegen\compiler-codegen.csproj" Properties="TargetFramework=net8.0">
       <Output TaskParameter="TargetOutputs" PropertyName="XcstCodeGen" />
     </MSBuild>
     <Message Text="xcst-codegen [$(MSBuildProjectName)]" Importance="high" />

--- a/src/Xcst.Runtime/Xcst.Runtime.csproj
+++ b/src/Xcst.Runtime/Xcst.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;net8.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>Xcst</RootNamespace>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/compiler-codegen/compiler-codegen.csproj
+++ b/src/compiler-codegen/compiler-codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/Xcst.Tests/Xcst.Tests.csproj
+++ b/tests/Xcst.Tests/Xcst.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/tests-codegen/tests-codegen.csproj
+++ b/tests/tests-codegen/tests-codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- Update all projects to .NET 8 LTS
- Allow compiler to be used as dependency in .NET projects